### PR TITLE
Handle final payments via Stripe function

### DIFF
--- a/app/(authenticated)/admin/dashboard/page.tsx
+++ b/app/(authenticated)/admin/dashboard/page.tsx
@@ -4,7 +4,7 @@ import React, { useState, useEffect } from 'react';
 import { useAuth } from '@/context/AuthContext';
 import { useRouter } from 'next/navigation';
 import { db as firestore } from '@/lib/firebase';
-import { collection, onSnapshot, query, orderBy, doc, updateDoc, Timestamp, getDoc, getDocs, addDoc, deleteDoc } from 'firebase/firestore';
+import { collection, onSnapshot, query, orderBy, doc, updateDoc, Timestamp, getDoc } from 'firebase/firestore';
 import { format } from 'date-fns';
 import { httpsCallable } from 'firebase/functions';
 import { functions as firebaseFunctions } from '@/lib/firebase';
@@ -196,39 +196,35 @@ const AdminDashboard = () => {
         updatedAt: new Date()
       };
 
-      // If there's a remaining balance, create a checkout session for final payment
+      // If there's a remaining balance, create a final payment intent via Cloud Function
       if (remainingBalance > 0) {
-        // Create checkout session for remaining balance using Stripe extension
-        const checkoutSessionRef = await addDoc(
-          collection(firestore, 'customers', booking.userId, 'checkout_sessions'),
-          {
-            mode: 'payment',
-            amount: remainingBalance * 100, // Convert to cents
-            currency: 'usd',
-            success_url: `${window.location.origin}/profile/bookings?success=true`,
-            cancel_url: `${window.location.origin}/profile/bookings`,
-            metadata: {
-              bookingId: booking.id,
-              paymentType: 'final',
-              description: `Final payment for session - remaining balance`
-            }
-          }
-        );
+        const chargeFinal = httpsCallable(firebaseFunctions, 'chargeFinalSessionPayment');
+        try {
+          const result: any = await chargeFinal({
+            bookingId: booking.id,
+            amount: remainingBalance,
+            customerEmail: booking.userEmail,
+          });
 
-        updates.finalPaymentSessionId = checkoutSessionRef.id;
-        updates.finalPaymentStatus = 'pending';
-        
-        // Add to payment history
-        const paymentHistory = booking.paymentHistory || [];
-        paymentHistory.push({
-          type: 'final_payment_created',
-          amount: remainingBalance,
-          timestamp: new Date(),
-          description: `Final payment session created for $${remainingBalance}`
-        });
-        updates.paymentHistory = paymentHistory;
-        
-        setActionSuccess(`Session completed! Final payment of $${remainingBalance} will be charged to customer.`);
+          if (result.data?.success) {
+            updates.finalPaymentIntentId = result.data.paymentIntentId;
+            updates.finalPaymentStatus = 'pending';
+          }
+
+          const paymentHistory = booking.paymentHistory || [];
+          paymentHistory.push({
+            type: 'final_payment_created',
+            amount: remainingBalance,
+            timestamp: new Date(),
+            description: `Final payment intent created for $${remainingBalance}`
+          });
+          updates.paymentHistory = paymentHistory;
+
+          setActionSuccess(`Session completed! Final payment of $${remainingBalance} will be charged to customer.`);
+        } catch (e) {
+          console.error('Final payment error:', e);
+          setActionError('Failed to create final payment');
+        }
       } else {
         updates.finalPaid = true;
         setActionSuccess('Session completed successfully! No additional payment required.');

--- a/app/(authenticated)/admin/schedule/page.tsx
+++ b/app/(authenticated)/admin/schedule/page.tsx
@@ -4,7 +4,7 @@ import React, { useState, useEffect } from 'react';
 import { useAuth } from '@/context/AuthContext';
 import { useRouter } from 'next/navigation';
 import { db as firestore } from '@/lib/firebase';
-import { collection, onSnapshot, query, where, Timestamp, updateDoc, doc, addDoc } from 'firebase/firestore';
+import { collection, onSnapshot, query, where, Timestamp, updateDoc, doc } from 'firebase/firestore';
 import { httpsCallable } from 'firebase/functions';
 import { functions as firebaseFunctions } from '@/lib/firebase';
 import { Calendar, dateFnsLocalizer, Event as BigCalendarEvent } from 'react-big-calendar';
@@ -41,6 +41,7 @@ interface ScheduleEvent extends BigCalendarEvent {
   depositPaid?: boolean;
   finalAmount?: number;
   finalPaid?: boolean;
+  finalPaymentIntentId?: string;
   notes?: string;
   paymentHistory?: any[];
 }
@@ -279,40 +280,30 @@ function BookingDetailsModal({
         console.log('Files to upload:', sessionFiles);
       }
 
-      // If there's a remaining balance, create a checkout session for final payment
+      // If there's a remaining balance, create a final payment intent via Cloud Function
       if (remainingBalance > 0) {
         try {
-          // Create checkout session for remaining balance using Stripe extension
-          const checkoutSessionRef = await addDoc(
-            collection(firestore, 'customers', booking.userId, 'checkout_sessions'),
-            {
-              mode: 'payment',
-              amount: remainingBalance * 100, // Convert to cents
-              currency: 'usd',
-              success_url: `${window.location.origin}/profile/bookings?success=true`,
-              cancel_url: `${window.location.origin}/profile/bookings`,
-              metadata: {
-                bookingId: booking.id,
-                paymentType: 'final',
-                description: `Final payment for ${booking.serviceName} session`
-              }
-            }
-          );
+          const chargeFinal = httpsCallable(firebaseFunctions, 'chargeFinalSessionPayment');
+          const result: any = await chargeFinal({
+            bookingId: booking.id,
+            amount: remainingBalance,
+            customerEmail: booking.customerEmail,
+          });
 
-          updates.finalPaymentSessionId = checkoutSessionRef.id;
-          updates.finalPaymentStatus = 'pending';
-          
-          // Add to payment history
+          if (result.data?.success) {
+            updates.finalPaymentIntentId = result.data.paymentIntentId;
+            updates.finalPaymentStatus = 'pending';
+          }
           const paymentHistory = booking.paymentHistory || [];
           paymentHistory.push({
             type: 'final_payment_created',
             amount: remainingBalance,
             timestamp: new Date(),
-            description: `Final payment session created for $${remainingBalance}`
+            description: `Final payment intent created for $${remainingBalance}`
           });
           updates.paymentHistory = paymentHistory;
         } catch (paymentError) {
-          console.error('Error creating final payment session:', paymentError);
+          console.error('Error creating final payment:', paymentError);
           // Continue with completion even if payment setup fails
         }
       } else {

--- a/firestore.rules
+++ b/firestore.rules
@@ -24,27 +24,6 @@ service cloud.firestore {
       allow read, write: if request.auth != null;
     }
 
-    // Stripe extension rules
-    match /customers/{uid} {
-      allow read: if request.auth.uid == uid;
-
-      match /checkout_sessions/{id} {
-        allow read, write: if request.auth.uid == uid;
-      }
-      match /subscriptions/{id} {
-        allow read: if request.auth.uid == uid;
-      }
-      match /payments/{id} {
-        allow read: if request.auth.uid == uid;
-      }
-    }
-
-    match /products/{id} {
-      allow read: if true;
-
-      match /prices/{id} {
-        allow read: if true;
-      }
-    }
+    // Removed Stripe extension rules
   }
 }

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -280,3 +280,47 @@ export const handleStripeWebhook = functions.https.onRequest(async (req, res) =>
     res.status(500).send('Webhook processing failed');
   }
 });
+
+// Charge final payment for a completed session (admin only)
+export const chargeFinalSessionPayment = functions.https.onCall(async (data, context) => {
+  if (!context.auth) {
+    throw new functions.https.HttpsError('unauthenticated', 'User must be authenticated');
+  }
+
+  const { bookingId, amount, customerEmail } = data;
+
+  if (!bookingId || typeof amount !== 'number') {
+    throw new functions.https.HttpsError('invalid-argument', 'bookingId and amount are required');
+  }
+
+  const userDoc = await db.collection('users').doc(context.auth.uid).get();
+  if (!userDoc.exists || !userDoc.data()?.isAdmin) {
+    throw new functions.https.HttpsError('permission-denied', 'Admin access required');
+  }
+
+  try {
+    const paymentIntent = await stripe.paymentIntents.create({
+      amount: Math.round(amount * 100),
+      currency: 'usd',
+      description: `Final payment for booking ${bookingId}`,
+      metadata: { bookingId, paymentType: 'final' },
+      automatic_payment_methods: { enabled: true },
+    });
+
+    await db.collection('bookings').doc(bookingId).update({
+      finalPaymentIntentId: paymentIntent.id,
+      finalPaymentAmount: amount,
+      finalPaymentStatus: 'pending',
+      updatedAt: admin.firestore.FieldValue.serverTimestamp(),
+    });
+
+    if (customerEmail) {
+      console.log(`Final payment invoice ready for ${customerEmail} - PaymentIntent: ${paymentIntent.id}`);
+    }
+
+    return { success: true, paymentIntentId: paymentIntent.id };
+  } catch (error) {
+    console.error('Error charging final payment:', error);
+    throw new functions.https.HttpsError('internal', 'Failed to charge final payment');
+  }
+});


### PR DESCRIPTION
## Summary
- call new `chargeFinalSessionPayment` cloud function for final booking payments
- add `chargeFinalSessionPayment` implementation
- clean up unused Stripe extension rules

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_b_6876d5bbe08c832994b627a599bb2214